### PR TITLE
Update CommandAPI

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,7 +76,7 @@ repositories {
     }
 }
 
-val commandAPIVersion = "10.1.2"
+val commandAPIVersion = "11.0.0"
 val skriptVersion = "2.13.1"
 
 dependencies {


### PR DESCRIPTION
Fixes 1.21.10 issue

!!!!!!!!!!!!!!!!!!!!!!!!! WARNING !!!!!!!!!!!!!!!!!!!!!!!!!
PLEASE TEST BEFORE UPLOADING TO MODRINTH, IT'S SOMETHING, IDK IF IT WORKS.
"[04:05:56] [Server thread/INFO]: [SkRedis] Loading server plugin SkRedis v2.1.0
[04:05:56] [Server thread/ERROR]: [SkRedis] Error initializing plugin 'SkRedis-2.1.0.jar' in folder 'plugins' (Is it up to date?)
java.lang.IllegalStateException: The CommandAPI's NMS hook failed to load! This version of the CommandAPI is Mojang-mapped. Have you checked that you are using a CommandAPI version that matches the mappings that your plugin is using?
	at dev.jorel.commandapi.CommandAPIVersionHandler.getPlatform(CommandAPIVersionHandler.java:102) ~[?:?]
	at dev.jorel.commandapi.CommandAPI.onLoad(CommandAPI.java:112) ~[?:?]
	at SkRedis-2.1.0.jar/dev.bypixel.skredis.Main.load(Main.kt:36) ~[SkRedis-2.1.0.jar:?]
	at net.axay.kspigot.main.KSpigot.onLoad(KSpigot.kt:63) ~[?:?]
	at io.papermc.paper.plugin.storage.ServerPluginProviderStorage.processProvided(ServerPluginProviderStorage.java:59) ~[purpur-1.21.10.jar:1.21.10-2506-d7de13d]
	at io.papermc.paper.plugin.storage.ServerPluginProviderStorage.processProvided(ServerPluginProviderStorage.java:18) ~[purpur-1.21.10.jar:1.21.10-2506-d7de13d]
	at io.papermc.paper.plugin.storage.SimpleProviderStorage.enter(SimpleProviderStorage.java:39) ~[purpur-1.21.10.jar:1.21.10-2506-d7de13d]
	at io.papermc.paper.plugin.entrypoint.LaunchEntryPointHandler.enter(LaunchEntryPointHandler.java:39) ~[purpur-1.21.10.jar:1.21.10-2506-d7de13d]
	at org.bukkit.craftbukkit.CraftServer.loadPlugins(CraftServer.java:569) ~[purpur-1.21.10.jar:1.21.10-2506-d7de13d]
	at net.minecraft.server.dedicated.DedicatedServer.initServer(DedicatedServer.java:357) ~[purpur-1.21.10.jar:1.21.10-2506-d7de13d]
	at net.minecraft.server.MinecraftServer.runServer(MinecraftServer.java:1245) ~[purpur-1.21.10.jar:1.21.10-2506-d7de13d]
	at net.minecraft.server.MinecraftServer.lambda$spin$2(MinecraftServer.java:357) ~[purpur-1.21.10.jar:1.21.10-2506-d7de13d]
	at java.base/java.lang.Thread.run(Thread.java:1583) ~[?:?]
Caused by: dev.jorel.commandapi.exceptions.UnsupportedVersionException: This version of Minecraft is unsupported: 1.21.10
	at dev.jorel.commandapi.CommandAPIVersionHandler.getPlatform(CommandAPIVersionHandler.java:94) ~[?:?]
	... 12 more" known as.